### PR TITLE
Fix chunked header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,8 @@
     "include-path": ["src/"],
     "autoload": {
         "files": ["src/Zend_MailJ.php"]
+    },
+    "require-dev": {
+        "phpunit/phpunit": "~4.5"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="vendor/autoload.php" colors="true" >
+    <testsuites>
+        <testsuite name="testcases" suffix=".php">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Zend_MailJ.php
+++ b/src/Zend_MailJ.php
@@ -41,30 +41,6 @@ class Zend_MailJ extends Zend_Mail
         return parent::setBodyText($txt, $charset, $encoding);
     }
 
-    public function setFrom($email, $name = null)
-    {
-        if ($name !== null) {
-            $name = $this->mbconvert($name);
-        }
-
-        return parent::setFrom($email, $name);
-    }
-
-    public function addTo($email, $name='')
-    {
-        if ($name !== '') {
-            $name = $this->mbconvert($name);
-        }
-
-        return parent::addTo($email, $name);
-    }
-
-    public function setSubject($subject)
-    {
-        $subject = $this->mbconvert($subject);
-        return parent::setSubject($subject);
-    }
-
     /**
      * override
      * @see Zend_Mail
@@ -82,21 +58,5 @@ class Zend_MailJ extends Zend_Mail
         }
 
         return $value;
-    }
-
-
-    /**
-     * Sets Default From-email and name of the message
-     *
-     * @param  string               $email
-     * @param  string    Optional   $name
-     * @return void
-     */
-    public static function setDefaultFrom($email, $name = null)
-    {
-        if ($name !== null) {
-            $name = self::mbconvert($name);
-        }
-        return parent::setDefaultFrom($email, $name);
     }
 }

--- a/tests/Zend_MailJTest.php
+++ b/tests/Zend_MailJTest.php
@@ -1,0 +1,71 @@
+<?php
+
+require_once 'Zend_MailJ.php';
+
+/**
+ * Mock mail transport class for testing purposes
+ *
+ * @category   Zend
+ * @package    Zend_Mail
+ * @subpackage UnitTests
+ * @copyright  Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license    http://framework.zend.com/license/new-bsd     New BSD License
+ */
+class Zend_Mail_Transport_Mock extends Zend_Mail_Transport_Abstract
+{
+	/**
+	 * @var Zend_Mail
+	 */
+	public $mail       = null;
+	public $returnPath = null;
+	public $subject    = null;
+	public $from       = null;
+	public $headers    = null;
+	public $called     = false;
+
+	public function _sendMail()
+	{
+		$this->mail       = $this->_mail;
+		$this->subject    = $this->_mail->getSubject();
+		$this->from       = $this->_mail->getFrom();
+		$this->returnPath = $this->_mail->getReturnPath();
+		$this->headers    = $this->_headers;
+		$this->called     = true;
+	}
+}
+
+class Zend_MailJTest extends PHPUnit_Framework_TestCase
+{
+	public function testJapaneseHeader_chunked()
+	{
+		mb_internal_encoding('utf-8');
+		$mail = new Zend_MailJ();
+		$testStr = 'あああああああああああああああああああああああああ';
+
+		$mail->addTo('to@example.com', $testStr);
+		$mail->setSubject($testStr);
+		$mail->setFrom('from@example.com', $testStr);
+		$mail->setBodyText('hogehoge');
+
+		$mock = new Zend_Mail_Transport_Mock();
+		$mail->send($mock);
+
+		$headerNames = array('To', 'Subject', 'From');
+
+		foreach($headerNames as $headerName) {
+			$header = $mock->headers[$headerName][0];
+			$blocks = array();
+
+			preg_match_all('/=\?(?<charset>.+?)\?(?<encoding>.+?)\?(?<body>.+?)\?=/', $header, $chunks, PREG_SET_ORDER);
+			$this->assertGreaterThanOrEqual(2, count($chunks), 'We want to test chunked header!');
+
+			foreach($chunks as $chunk) {
+				$this->assertSame('ISO-2022-JP', $chunk['charset']);
+				$this->assertSame('B', $chunk['encoding']);
+				// All chunks started with Japanese character should have escape sequence for compatibility.
+				$this->assertStringStartsWith('GyRC', $chunk['body']);
+			}
+		}
+	}
+}
+


### PR DESCRIPTION
You don't need to `mb_convert_encoding` because `mb_encode_mimeheader` do that.

Additionally, each chunk should have `GyRC` escape sequence if it starts with Japanese character. Encoding conversion in `mb_encode_mimeheader` treats it well.

See also: http://wiki.rookie-inc.com/development/language/php/tips/mb_encode_mimeheader
